### PR TITLE
Remove invocation of Git::More::nocarp

### DIFF
--- a/lib/Git/Hooks/RubyNoDebugger.pm
+++ b/lib/Git/Hooks/RubyNoDebugger.pm
@@ -17,7 +17,6 @@ sub check_commit
 
     my $success = 1;
 
-    $git->nocarp;
     # $git->get_config;
 
     for my $file (@files) {


### PR DESCRIPTION
I just released a TRIAL version 2.0.0 of Git::Hooks which introduces some incompatible changes.

I think your plugin needs just a small change to make it compatible with any version of Git::Hooks. I haven't tested it though...